### PR TITLE
change a-player preload to none

### DIFF
--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -1,12 +1,14 @@
 <template>
   <span class="news-item">
     <div>
-      <a-player :music="{
-        title: item.title.rendered || ' ',
-        author: ' ',
-        url: item.mp3 || ' ',
-        pic: item.featuredImage || ' ',
-        lrc: '[00:00.00]lrc here\n[00:01.00]aplayer'
+      <a-player
+        preload='none'
+        :music="{
+            title: item.title.rendered || ' ',
+            author: ' ',
+            url: item.mp3 || ' ',
+            pic: item.featuredImage || ' ',
+            lrc: '[00:00.00]lrc here\n[00:01.00]aplayer'
       }"></a-player>
     </div>
     <span class="score">


### PR DESCRIPTION
Resolves issue #32 

@jasonify  - Try this out and see if it resolves the issue. If you want mp3s preloaded in `ItemView.vue` but not the list Views we'll need additional logic but I'm not sure if we (or the users) would want that.