### PR TITLE
Add API to send events

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -6,6 +6,7 @@ import relatedLinksActions from './actions/relatedLinks.actions'
 import playerActions from './actions/player.actions'
 import feedActions from './actions/feed.actions'
 import subscriptionActions from './actions/subscription.actions'
+import loggingPostActions from './actions/logging.post.actions'
 
 export default {
   ...authActions,
@@ -15,5 +16,6 @@ export default {
   ...playerActions,
   ...postActions,
   ...subscriptionActions,
-  ...feedActions
+  ...feedActions,
+  ...loggingPostActions
 }

--- a/src/store/actions/config.js
+++ b/src/store/actions/config.js
@@ -12,5 +12,8 @@ module.exports = {
   // 'STRIPE_PUBLIC_KEY': 'pk_test_vMQkcW5KspBBOQ0hn5nNshDm'
 
   // PRODUCTION:
-  'STRIPE_PUBLIC_KEY': 'pk_live_Cfttsv5i5ZG5IBfrmllzNoSA'
+  'STRIPE_PUBLIC_KEY': 'pk_live_Cfttsv5i5ZG5IBfrmllzNoSA',
+
+  // PRODUCTION:
+  'EVENTS_API_BASE_URL': 'http://ec2-54-201-88-214.us-west-2.compute.amazonaws.com:3000/api/v1/event'
 }

--- a/src/store/actions/logging.post.actions.js
+++ b/src/store/actions/logging.post.actions.js
@@ -1,0 +1,39 @@
+import axios from 'axios'
+import { EVENTS_API_BASE_URL } from './config.js'
+
+export default {
+  enableLogging: ({ commit, getters, state }) => {
+    const token = getters.getToken
+    if (!token) {
+      alert('Login to enable logging')
+      return
+    }
+    commit('enableLogging')
+  },
+
+  disableLogging: ({ commit, getters, state }) => {
+    const token = getters.getToken
+    if (!token) {
+      alert('Login to disable logging')
+      return
+    }
+    commit('disableLogging')
+  },
+
+  registerEvent: ({ commit, state }, { username }) => {
+    return axios.post(`${EVENTS_API_BASE_URL}`, {
+      clientId: username,
+      deviceType: 'Browser',
+      eventTime: new Date().getTime(),
+      eventType: 'register',
+      eventData: {}
+    })
+      .then((response) => {
+        return response
+      })
+      .catch((error) => {
+        console.log(error.response)
+        return error
+      })
+  }
+}

--- a/src/store/initialState.js
+++ b/src/store/initialState.js
@@ -16,5 +16,6 @@ export default {
     new: [],
     recommendation: []
   },
+  loggingEnabled: true,
   token: localStorage.getItem('token')
 }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -169,5 +169,14 @@ export default {
   setToken: (state, { token }) => {
     localStorage.setItem('token', token)
     state.token = token
+  },
+
+  enableLogging: (state) => {
+    state.loggingEnabled = true
+  },
+
+  disableLogging: (state) => {
+    state.loggingEnabled = false
   }
+
 }

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -138,7 +138,7 @@ export default {
                   username
                 })
                   .then((eventResponse) => {
-                    // hello
+                    // Ignore response for now
                   })
                 if (wantedToSubscribe()) {
                   this.$router.replace('/subscribe')

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -134,6 +134,12 @@ export default {
               this.loading = false
 
               if (response.data.token) {
+                this.$store.dispatch('registerEvent', {
+                  username
+                })
+                  .then((eventResponse) => {
+                    // hello
+                  })
                 if (wantedToSubscribe()) {
                   this.$router.replace('/subscribe')
                 } else {


### PR DESCRIPTION
Adding the ability to send register events to the [event stream](https://github.com/SoftwareEngineeringDaily/sedaily-event-stream) API. This is dependent on removing the field for `location` and adding the `register` event type: see this [pull request](https://github.com/SoftwareEngineeringDaily/sedaily-event-stream/pull/35). I don't think we ever defined what the location should be. We can add that in later. I added the call to send the event in the  view in favor of the register action