### PR TITLE
fix JobBoardView filtered data prop

### DIFF
--- a/src/views/JobsBoardView.vue
+++ b/src/views/JobsBoardView.vue
@@ -87,7 +87,7 @@ export default {
     return {
       loading: false,
       error: null,
-      isFiltered: false,
+      filtered: false,
       locationSearch: '',
       keywordSearch: '',
       displayedJobs: []


### PR DESCRIPTION
resolves #252 

`filtered` was missing in the component's data function (`isFiltered` was there instead). It still worked despite the Vue errors because on initial render it was `undefined` and thus "falsy".