### PR TITLE
Fix disappearing text on subscribe button

### DIFF
--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -199,7 +199,11 @@ export default {
     border-radius 20px
     padding-top 4px
     text-decoration none
+    transition background-color .15s ease
     margin-right 1em
+    &:hover
+      color #fff
+      background-color #a591ff
   .register-nav-link
     margin-right 1em
 


### PR DESCRIPTION
When hovering over the SUBSCRIBE button, the text would turn to primary color, causing the text to become unreadable to the user.