### PR TITLE
Make user profile images circular

### DIFF
--- a/src/components/ProfileDetails.vue
+++ b/src/components/ProfileDetails.vue
@@ -6,7 +6,9 @@
         </router-link>
       </h6>
       <div class="col col-sm-auto">
-        <img class="profile-img" :src="avatarUrl" />
+        <div class="crop-image">
+          <img class="profile-img" :src="avatarUrl" />
+        </div>
       </div>
       <div class="col-sm-6 col-md-4">
         <h4>
@@ -68,8 +70,19 @@
   .profile-details
     padding-top 5px
 
-  .profile-img
+  .crop-image
+    background-position 50%
+    background-repeat no-repeat
+    border-radius 50%
     width 100px
+    height 100px
+    overflow hidden
+
+  .profile-img
+    display inline
+    margin 0 auto
+    height 100%
+    width auto
 
   .edit-link
     a


### PR DESCRIPTION
Images were full sized at their height set to 100px, this made profile images pretty small on the profile details component. I went ahead and made these images bigger, while making the profile image circular.