### PR TITLE
AuthPlugin logout setMe to {}

### DIFF
--- a/src/plugins/AuthPlugin.js
+++ b/src/plugins/AuthPlugin.js
@@ -41,7 +41,7 @@ export default {
 
   logout () {
     this.clearToken()
-    store.commit('setMe', null)
+    store.commit('setMe', {})
   },
 
   setAuthHeader (config, token) {

--- a/src/views/ForumThreadView.vue
+++ b/src/views/ForumThreadView.vue
@@ -108,7 +108,7 @@ export default {
           return true
         }
         */
-        return this.me && this.me._id === this.forumThread.author._id
+        return this.me._id === this.forumThread.author._id
       } else {
         return false
       }


### PR DESCRIPTION
This is alternate and better fix for PR  #418 

This will ensure consistent behaviour between initially not being logged in and then logging out. `me` should be `{}` in both cases.