### PR TITLE
Fix fonts and CSS styling on forums

### DIFF
--- a/src/components/ForumThreadSummary.vue
+++ b/src/components/ForumThreadSummary.vue
@@ -88,6 +88,8 @@ export default {
     color #000
     font-weight light
     font-size 1.0rem
+    &:visited
+      color #a9a9a9
   .forum-summary-title a:hover
     text-decoration none
     color primary-color

--- a/src/components/ForumThreadSummary.vue
+++ b/src/components/ForumThreadSummary.vue
@@ -83,10 +83,10 @@ export default {
 @import '../css/variables'
 
 .forum-summary-container
-  font-family Roboto-Light
+  font-family Roboto
   .forum-summary-title a
     color #000
-    font-weight 300
+    font-weight light
     font-size 1.0rem
   .forum-summary-title a:hover
     text-decoration none
@@ -100,8 +100,13 @@ export default {
   margin-top 3px
   margin-bottom 1rem
 
-.comments-count-link
+.forum-thread-misc a
+  text-decoration none
+
+.misc-detail a
   color #a9a9a9
+  &:hover
+    color idle-foreground
 .bullet-point
   display inline-flex
   font-size 0.65em


### PR DESCRIPTION
For users who did not have Roboto-Light installed on their computer, the fonts would default to Times. Also, `.comments-count-link` was referenced in CSS but did not seem to style anything, this was changed to `.forum-thread-misc a`, I've also removed `text-decoration` on author and comments. 

Here is a screenshot of the proposed changes:
![screenshot 26](https://user-images.githubusercontent.com/18516968/38961500-129cd5a0-4326-11e8-986d-39f325dbb213.png)
