### PR TITLE
Fix font for "see preview below"

### DIFF
--- a/src/components/ForumThreadCompose.vue
+++ b/src/components/ForumThreadCompose.vue
@@ -222,7 +222,7 @@ export default {
   padding-top 10px
   padding-left 5px
   color #8c8c8c
-  font-family Roboto-Italic
+  font-style italic
 
 .forum-title-box
   width 100%


### PR DESCRIPTION
Times was showing up instead of Roboto, roboto is already the default font for this, just removed the extra style and added italic as the `font-style`.

<img width="884" alt="screen shot 2018-04-19 at 8 32 55 am" src="https://user-images.githubusercontent.com/18516968/38998235-5ad7a922-43ac-11e8-85c7-ca7be6a5f728.png">
