### PR TITLE
Fix max width of forum titles

### DIFF
--- a/src/components/ForumThreadSummary.vue
+++ b/src/components/ForumThreadSummary.vue
@@ -94,8 +94,6 @@ export default {
     text-decoration none
     color primary-color
 
-.content-holder
-  max-width 63%
 .forum-thread-misc
   font-size 0.8rem
   color darkgrey
@@ -126,6 +124,9 @@ export default {
   .votes-container
     padding 0px 10px
     padding-left 15px
+@media (max-width: 576px)
+  .content-holder
+    max-width 63%
 
 
 </style>


### PR DESCRIPTION
Moved `max-width` to it's own media query for widths less than 576px.

_Full width_
![screenshot 41](https://user-images.githubusercontent.com/18516968/39074338-2baff7aa-44ae-11e8-9976-1f682249cd22.png)

_Width less than 576px_
![screenshot 42](https://user-images.githubusercontent.com/18516968/39074376-465c49a0-44ae-11e8-9100-1dd2920b54bc.png)


