### PR TITLE
Fix issue with super long titles

### DIFF
--- a/src/components/ForumThreadSummary.vue
+++ b/src/components/ForumThreadSummary.vue
@@ -103,6 +103,8 @@ export default {
 .forum-thread-misc a
   text-decoration none
 
+.content-holder
+  max-width 83%
 .misc-detail a
   color #a9a9a9
   &:hover


### PR DESCRIPTION
Super long titles would justify the thread to the left, 83% as a `max-width` seems to provide the best layout.

_Before_
<img width="1542" alt="screen shot 2018-04-20 at 3 22 21 pm" src="https://user-images.githubusercontent.com/18516968/39076445-961ddbfc-44b8-11e8-84ba-fea27314946f.png">

_After (ignore the navigation bar)_
![screenshot 44](https://user-images.githubusercontent.com/18516968/39076450-a80c209e-44b8-11e8-8a22-313c321e4ce9.png)


