### PR TITLE
Event handler for when an external url is clicked

### DIFF
--- a/src/components/RelatedLinkList.vue
+++ b/src/components/RelatedLinkList.vue
@@ -2,9 +2,11 @@
   <div>
     <h4 class='section-title'> Related Links </h4>
     <div v-for="relatedLink in relatedLinks" class="related-links-list" :key="relatedLink._id">
-      <related-link :relatedLink="relatedLink"> </related-link>
+      <div @click="logLink(relatedLink.url)">
+        <related-link :relatedLink="relatedLink"></related-link>
+      </div>
     </div>
-</div>
+  </div>
 </template>
 
 <script>
@@ -23,6 +25,11 @@ export default {
     return {
       loading: true,
       username: null
+    }
+  },
+  methods: {
+    logLink (url) {
+      console.log(url)
     }
   }
 }


### PR DESCRIPTION
When a user clicks a related link, it will now fire an event handler. Right now it is just a `console.log(url)` to log the clicked link. But you can access any field from a `RelatedLink` object.

Closes #497  