### PR TITLE
Fix time for posts/edits/comments

### DIFF
--- a/src/components/CommentView.vue
+++ b/src/components/CommentView.vue
@@ -223,7 +223,7 @@ export default {
 
     date (comment) {
       if (comment.dateCreated) {
-        return moment(comment.dateCreated).startOf('hour').fromNow()
+        return moment(comment.dateCreated).startOf('second').fromNow()
       } else {
         return 'Now'
       }

--- a/src/components/ForumThreadSummary.vue
+++ b/src/components/ForumThreadSummary.vue
@@ -96,7 +96,7 @@ export default {
     lastAcitivityDate () {
       if (this.forumThread) {
         return moment(this.forumThread.dateLastAcitiy)
-          .startOf('hour').fromNow()
+          .startOf('second').fromNow()
       }
     }
   }

--- a/src/components/LastEditedInfo.vue
+++ b/src/components/LastEditedInfo.vue
@@ -19,7 +19,7 @@ export default {
     lastEdited () {
       if (!this.lastEditedTimestamp) return false
       return moment(this.lastEditedTimestamp)
-      .startOf('hour').fromNow()
+      .startOf('second').fromNow()
     }
   }
 }

--- a/src/views/ForumThreadView.vue
+++ b/src/views/ForumThreadView.vue
@@ -100,7 +100,7 @@ export default {
     creationDate () {
       if (this.forumThread) {
         return moment(this.forumThread.dateCreated)
-          .startOf('hour').fromNow()
+          .startOf('second').fromNow()
       }
     },
     isMyThread () {


### PR DESCRIPTION
There was an issue with post, edit, and comment times being displayed incorrectly. This should fix it, before it was returning the moment from the start of the hour, I've changed it to calculate from the start of the second.

Closes #491 