### PR TITLE
Show linter errors in DOM

### DIFF
--- a/build/webpack.dev.conf.js
+++ b/build/webpack.dev.conf.js
@@ -17,7 +17,8 @@ module.exports = merge(baseWebpackConfig, {
     contentBase: path.join(__dirname, 'dist'),
     open: true,
     compress: true,
-    historyApiFallback: true
+    historyApiFallback: true,
+    overlay: true
   },
   plugins: [
     new webpack.DefinePlugin({


### PR DESCRIPTION
The linter was not showing errors in the DOM, now errors display as an overlay :)

Closes #501 