### PR TITLE
Remove extra closing div

### DIFF
--- a/src/views/PostDetailsView.vue
+++ b/src/views/PostDetailsView.vue
@@ -69,7 +69,6 @@
       <comment-compose v-if="forumThreadId"
         :entityId="forumThreadId"
         :rootEntityType='"forumthread"' />
-      />
       <br>
       <h3 class="section-title"> Comments </h3>
       <comments-list


### PR DESCRIPTION
There is an `/>` appearing above the `Comments` header when viewing the comments tab on an episode.

![image](https://user-images.githubusercontent.com/8145759/49948269-1fc5cc80-fec1-11e8-83fb-97092e57182f.png)
